### PR TITLE
Decouple action vocabulary from intended objects in order to promote action reusability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# JetBrains IDE
+.idea/
+*.iml
+*.ipr
+*.iws
+*.uml
+out/

--- a/README.md
+++ b/README.md
@@ -21,22 +21,22 @@ alignmentUrl   |            |             | schema:targetUrl
 
 ## Actions
 
-Action              | IRI       | Description
---------------------|-----------|------------
-Defined      | http://purl.imsglobal.org/vocab/caliper/action#Defined       | Defined a new BadgeClass or Issuer
-Issued         | http://purl.imsglobal.org/vocab/caliper/action#Issued       | Awarded an instance of a BadgeClass to a recipient, perhaps accepting an application
-Modified             | http://purl.imsglobal.org/vocab/caliper/action#Modified       | Modified or updated a previously defined badge object with new metadata
-Revoked        | http://purl.imsglobal.org/vocab/caliper/action#Revoked       | Updated a previously awarded badge to mark it as revoked
-Deleted             | http://purl.imsglobal.org/vocab/caliper/action#Deleted       | Marked a defined badge object as deleted
-Registered          | http://purl.imsglobal.org/vocab/caliper/action#Registered       | Registered a recipient profile with a backpack endpoint or issuer profile with issuer endpoint
-Requested           | http://purl.imsglobal.org/vocab/caliper/action#       | Requested a badge object or related resource from an issuer or repository
-Verified            | http://purl.imsglobal.org/vocab/caliper/action#Verified       | Verified an Open Badge's authenticity and structural integrity
-Shared              | http://purl.imsglobal.org/vocab/caliper/action#Shared       | Triggered or authorized a share of a single badge, collection, or other document including badges
-Endorsed            | http://purl.imsglobal.org/vocab/caliper/action#Endorsed       | Issued an endorsement or annotation of an Issuer, BadgeClass, or Assertion that should be published
-Displayed           | http://purl.imsglobal.org/vocab/caliper/action#Displayed       | Displayed badge details on a single badge to a consumer
-Accepted            | http://purl.imsglobal.org/vocab/caliper/action#Accepted       | Inspected a badge or pathway with completion data and accepted it in exchange for some privilege, opportunity, access, or other benefit granted to the recipient.
-Applied             | http://purl.imsglobal.org/vocab/caliper/action#Applied       | User submits evidence to an issuer in hopes of earning a badge.
-AssignedTo | http://purl.imsglobal.org/vocab/caliper/action#AssignedTo       | Set BadgeClass as related to prospective opportunity, privilege, objective, learning pathway, skill or competency definition
+Action | IRI | Description | New   |
+-------|-----|------------ | :---: |
+Defined | http://purl.imsglobal.org/vocab/caliper/action#Defined | Defined a new BadgeClass or Issuer | Yes |
+Issued  | http://purl.imsglobal.org/vocab/caliper/action#Issued | Awarded an instance of a BadgeClass to a recipient, perhaps accepting an application | Yes
+Modified | http://purl.imsglobal.org/vocab/caliper/action#Modified | Modified or updated a previously defined badge object with new metadata | No
+Revoked | http://purl.imsglobal.org/vocab/caliper/action#Revoked | Updated a previously awarded badge to mark it as revoked | Yes
+Deleted | http://purl.imsglobal.org/vocab/caliper/action#Deleted | Marked a defined badge object as deleted | No
+Registered | http://purl.imsglobal.org/vocab/caliper/action#Registered | Registered a recipient profile with a backpack endpoint or issuer profile with issuer endpoint | Yes
+Requested | http://purl.imsglobal.org/vocab/caliper/action#Requested | Requested a badge object or related resource from an issuer or repository | Yes
+Verified | http://purl.imsglobal.org/vocab/caliper/action#Verified | Verified an Open Badge's authenticity and structural integrity | Yes
+Shared | http://purl.imsglobal.org/vocab/caliper/action#Shared | Triggered or authorized a share of a single badge, collection, or other document including badges | No
+Endorsed | http://purl.imsglobal.org/vocab/caliper/action#Endorsed | Issued an endorsement or annotation of an Issuer, BadgeClass, or Assertion that should be published | Yes
+Displayed | http://purl.imsglobal.org/vocab/caliper/action#Displayed | Displayed badge details on a single badge to a consumer | Yes
+Accepted | http://purl.imsglobal.org/vocab/caliper/action#Accepted | Inspected a badge or pathway with completion data and accepted it in exchange for some privilege, opportunity, access, or other benefit granted to the recipient. | Yes
+Applied | http://purl.imsglobal.org/vocab/caliper/action#Applied | User submits evidence to an issuer in hopes of earning a badge. | Yes
+AssignedTo | http://purl.imsglobal.org/vocab/caliper/action#AssignedTo | Set BadgeClass as related to prospective opportunity, privilege, objective, learning pathway, skill or competency definition | Yes
 
 ## Open Badges Event
 

--- a/README.md
+++ b/README.md
@@ -23,21 +23,20 @@ alignmentUrl   |            |             | schema:targetUrl
 
 Action              | IRI       | Description
 --------------------|-----------|------------
-DefinedIssuer       | TBA       | Defined a new Issuer Profile
-DefinedBadge        | TBA       | Defined a new BadgeClass
-IssuedBadge         | TBA       | Awarded an instance of a BadgeClass to a recipient, perhaps accepting an application
-Updated             | TBA       | Updated a previously defined badge object with new metadata
-RevokedBadge        | TBA       | Updated a previously awarded badge to mark it as revoked
-Deleted             | TBA       | Marked a defined badge object as deleted
-Registered          | TBA       | Registered a recipient profile with a backpack endpoint or issuer profile with issuer endpoint
-Requested           | TBA       | Requested a badge object or related resource from an issuer or repository
-Verified            | TBA       | Verified an Open Badge's authenticity and structural integrity
-Shared              | TBA       | Triggered or authorized a share of a single badge, collection, or other document including badges
-Endorsed            | TBA       | Issued an endorsement or annotation of an Issuer, BadgeClass, or Assertion that should be published
-Displayed           | TBA       | Displayed badge details on a single badge to a consumer
-Accepted            | TBA       | Inspected a badge or pathway with completion data and accepted it in exchange for some privilege, opportunity, access, or other benefit granted to the recipient.
-Applied             | TBA       | User submits evidence to an issuer in hopes of earning a badge.
-AssignedToObjective | TBA       | Set BadgeClass as related to prospective opportunity, privilege, objective, learning pathway, skill or competency definition
+Defined      | http://purl.imsglobal.org/vocab/caliper/action#Defined       | Defined a new BadgeClass or Issuer
+Issued         | http://purl.imsglobal.org/vocab/caliper/action#Issued       | Awarded an instance of a BadgeClass to a recipient, perhaps accepting an application
+Modified             | http://purl.imsglobal.org/vocab/caliper/action#Modified       | Modified or updated a previously defined badge object with new metadata
+Revoked        | http://purl.imsglobal.org/vocab/caliper/action#Revoked       | Updated a previously awarded badge to mark it as revoked
+Deleted             | http://purl.imsglobal.org/vocab/caliper/action#Deleted       | Marked a defined badge object as deleted
+Registered          | http://purl.imsglobal.org/vocab/caliper/action#Registered       | Registered a recipient profile with a backpack endpoint or issuer profile with issuer endpoint
+Requested           | http://purl.imsglobal.org/vocab/caliper/action#       | Requested a badge object or related resource from an issuer or repository
+Verified            | http://purl.imsglobal.org/vocab/caliper/action#Verified       | Verified an Open Badge's authenticity and structural integrity
+Shared              | http://purl.imsglobal.org/vocab/caliper/action#Shared       | Triggered or authorized a share of a single badge, collection, or other document including badges
+Endorsed            | http://purl.imsglobal.org/vocab/caliper/action#Endorsed       | Issued an endorsement or annotation of an Issuer, BadgeClass, or Assertion that should be published
+Displayed           | http://purl.imsglobal.org/vocab/caliper/action#Displayed       | Displayed badge details on a single badge to a consumer
+Accepted            | http://purl.imsglobal.org/vocab/caliper/action#Accepted       | Inspected a badge or pathway with completion data and accepted it in exchange for some privilege, opportunity, access, or other benefit granted to the recipient.
+Applied             | http://purl.imsglobal.org/vocab/caliper/action#Applied       | User submits evidence to an issuer in hopes of earning a badge.
+AssignedTo | http://purl.imsglobal.org/vocab/caliper/action#AssignedTo       | Set BadgeClass as related to prospective opportunity, privilege, objective, learning pathway, skill or competency definition
 
 ## Open Badges Event
 


### PR DESCRIPTION
This PR includes the following changes:

1) Replaces the [action][Object] construction with the action term only in order to promote the reusability of terms
2) Replaces `Updated` with `Modified`
3) Adds action IRIs
4) add .gitignore to filter out files that are local in nature such as my Webstorm IDE files.